### PR TITLE
docs: remove unused notation from consensus readme

### DIFF
--- a/consensus/README.md
+++ b/consensus/README.md
@@ -11,7 +11,6 @@ be interpreted as described in [RFC 2119](https://tools.ietf.org/html/rfc2119).
 ## Notation
 
 - `x || y`, x concatenated with y
-- `sk <- rand(1^n)`, sample a random n bit number
 
 ## Overview
 


### PR DESCRIPTION
This PR is supported by the Æternity Crypto Foundation